### PR TITLE
Add .gitignore into scripts/chapter7

### DIFF
--- a/scripts/chapter7/.gitignore
+++ b/scripts/chapter7/.gitignore
@@ -1,0 +1,38 @@
+# Python環境
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.so
+*.egg
+*.egg-info/
+dist/
+build/
+
+# 環境変数（APIキー含む）
+.env
+.env.local
+
+# テスト・カバレッジ
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# IDE設定
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS生成ファイル
+.DS_Store
+Thumbs.db
+
+# 一時出力（再生成不要な場合）
+# outputs/  # コミット対象のためコメントアウト
+*.log
+*.tmp


### PR DESCRIPTION
`.env` を使う前提になっているが、他のチャプターと違って `.gitignore` ファイルがなかったため。
リポジトリルートに配置するのも良いと思いますが、既存のディレクトリに合わせる形で chapter3 の物をそのまま持ってきています。