### PR TITLE
Set return_intermediate_steps to True

### DIFF
--- a/scripts/chapter7/7-3_react_search.py
+++ b/scripts/chapter7/7-3_react_search.py
@@ -136,6 +136,7 @@ Action Input: ツールへの入力内容
         max_iterations=MAX_ITERATIONS,
         verbose=True,
         handle_parsing_errors=True,
+        return_intermediate_steps=True,
     )
 
 def main(query: Optional[str] = None, model: str = "gpt-4o-mini", stop_sequence: bool = True) -> None:


### PR DESCRIPTION
`return_intermediate_steps`:
https://github.com/langchain-ai/langchain/blob/langchain%3D%3D0.3.27/libs/langchain/langchain/agents/agent.py#L1050C5-L1052

これがないと `chapter7` の `uv run 7-3_react_search.py` の出力は以下のようになります:

```
[Summary] steps=0 tool_calls=0 sources=0 satisfied=False                                                                                                                
```

この修正によって以下のようになります:

```
[Summary] steps=1 tool_calls=1 sources=3 satisfied=False
```

なお、`satisfied=False` なのは、最終的な出力が `Final Answer:` ではなく `最終回答:` となってしまうためのようです:

```
最終回答:

2025年の生成AI業界の主要な動向は以下の3つです。
...
```

こちらについては特に対処していません。